### PR TITLE
Allow multiple reaction role messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ __pycache__
 *.dev
 *.toml
 *.db
+*.diff

--- a/Config.toml.example
+++ b/Config.toml.example
@@ -6,13 +6,13 @@ guild_ids = [182892283111276544] # Guilds to register slash commands on.
 [commands]
 eval_timeout = 10.0
 
-[reaction_roles.color_roles]
+[reaction_roles.color_roles] # there can be multiple reaction_roles
 message_id = 960190427456221224
 # Match the role id and the emoji name with indexes.
 role_ids = [960191030479704115, 960191078248628234, 960205154488037436]
 emoji_names = ["💜", "💚", "doggo"]
 
-[[notifications]]
+[[notifications]] # there can be multiple notifications
 channel_id = 911224587931488296
 message = "Test"
 cron = "0 11 * * *"

--- a/src/config.py
+++ b/src/config.py
@@ -11,18 +11,10 @@ class ConfigDiscord(t.Dict[str, t.Any]):
         self.__dict__ = self
 
 
-class ConfigColorRoles(t.Dict[str, t.Any]):
+class ConfigReactionRoles(t.Dict[str, t.Any]):
     message_id: int
     role_ids: t.List[int]
     emoji_names: t.List[str]
-
-    def __init__(self, *args: t.Any, **kwargs: t.Any) -> None:
-        super(ConfigColorRoles, self).__init__(*args, **kwargs)
-        self.__dict__ = self
-
-
-class ConfigReactionRoles(t.Dict[str, t.Any]):
-    color_roles: ConfigColorRoles
 
     def __init__(self, *args: t.Any, **kwargs: t.Any) -> None:
         super(ConfigReactionRoles, self).__init__(*args, **kwargs)
@@ -49,7 +41,7 @@ class ConfigCommands(t.Dict[str, t.Any]):
 
 class Config(t.Dict[str, t.Any]):
     discord: ConfigDiscord
-    reaction_roles: ConfigReactionRoles
+    reaction_roles: t.Dict[str, ConfigReactionRoles]
     notifications: t.List[ConfigNotifications]
     commands: ConfigCommands
 

--- a/src/plugins/reaction_roles.py
+++ b/src/plugins/reaction_roles.py
@@ -1,3 +1,6 @@
+import logging
+import typing as t
+
 import hikari
 
 from src import utils, main
@@ -7,44 +10,47 @@ plugin = utils.Plugin("Reaction roles", include_datastore=True)
 
 @plugin.listener(hikari.StartingEvent, bind=True)
 async def load_roles_and_emojis(plug: utils.Plugin, _: hikari.StartingEvent) -> None:
-    conf = plug.bot.config.reaction_roles
-    plug.d.roles_emojis = dict(
-        zip(conf.color_roles.emoji_names, conf.color_roles.role_ids)
-    )
+    reaction_roles = plug.bot.config.reaction_roles
+
+    rr: t.Dict[int, t.Dict[str, int]] = {}
+
+    for (key, value) in reaction_roles.items():
+        logging.info(f"Loading reaction role '{key}'")
+        rr[value.message_id] = dict(zip(value.emoji_names, value.role_ids))
+
+    plug.d.reaction_roles = rr
 
 
 @plugin.listener(hikari.GuildReactionAddEvent, bind=True)
 async def reaction_add_event(
     plug: utils.Plugin, event: hikari.GuildReactionAddEvent
 ) -> None:
-    conf = plug.bot.config.reaction_roles
+    for (message_id, rr) in plug.d.reaction_roles.items():
+        if event.message_id == message_id:
+            emoji_name = str(event.emoji_name)
 
-    if event.message_id == conf.color_roles.message_id:
-        emoji_name = str(event.emoji_name)
+            role_id = rr.get(emoji_name)
 
-        role_id = plug.d.roles_emojis.get(emoji_name)
-
-        if role_id:
-            await plug.bot.rest.add_role_to_member(
-                event.guild_id, event.user_id, role_id
-            )
+            if role_id:
+                await plug.bot.rest.add_role_to_member(
+                    event.guild_id, event.user_id, role_id
+                )
 
 
 @plugin.listener(hikari.GuildReactionDeleteEvent, bind=True)
 async def reaction_remove_event(
     plug: utils.Plugin, event: hikari.GuildReactionDeleteEvent
 ) -> None:
-    conf = plug.bot.config.reaction_roles
+    for (message_id, rr) in plug.d.reaction_roles.items():
+        if event.message_id == message_id:
+            emoji_name = str(event.emoji_name)
 
-    if event.message_id == conf.color_roles.message_id:
-        emoji_name = str(event.emoji_name)
+            role_id = rr.get(emoji_name)
 
-        role_id = plug.d.roles_emojis.get(emoji_name)
-
-        if role_id:
-            await plug.bot.rest.remove_role_from_member(
-                event.guild_id, event.user_id, role_id
-            )
+            if role_id:
+                await plug.bot.rest.remove_role_from_member(
+                    event.guild_id, event.user_id, role_id
+                )
 
 
 def load(bot: main.CiberBot) -> None:


### PR DESCRIPTION
Modifica la estructura de la configuració per a permetre múltiples missatges que puguin donar rols.

	modified:   .gitignore
	modified:   Config.toml.example
	modified:   src/config.py
	modified:   src/plugins/reaction_roles.py