### PR TITLE
improvements to fxurl

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -43,3 +43,7 @@ ignore_missing_imports = true
 
 [mypy-text_unidecode.*]
 ignore_missing_imports = true
+
+# temporal until marked as typed (https://github.com/w4rum/discord-markdown-ast-parser/issues/1)
+[mypy-discord_markdown_ast_parser.*]
+ignore_missing_imports = true

--- a/mypy.ini
+++ b/mypy.ini
@@ -40,3 +40,6 @@ ignore_missing_imports = true
 
 [mypy-shortuuid.*]
 ignore_missing_imports = true
+
+[mypy-text_unidecode.*]
+ignore_missing_imports = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 hikari[speedups]==2.0.0.dev118
 hikari-lightbulb[crontrigger]==2.3.3
 
+discord-markdown-ast-parser==1.0.6
+
 aiofiles==23.1.0
 cassandra-driver==3.26.0
 shortuuid==1.0.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,8 @@ aiofiles==23.1.0
 cassandra-driver==3.26.0
 shortuuid==1.0.11
 
+text-unidecode==1.3
+
 uvloop>=0.17; sys_platform != "win32"
 aiohttp==3.8.4
 toml==0.10.2

--- a/src/plugins/fxurl.py
+++ b/src/plugins/fxurl.py
@@ -30,16 +30,17 @@ async def on_message(event: hikari.MessageCreateEvent) -> None:
 
     msg_to_send = ""
 
-    for i in urls:
+    for idx, i in enumerate(urls):
         url = urlparse(i)
-        if "twitter" in url.netloc and "fx" not in url.netloc:
+        if "twitter" in url.netloc and "fx" not in url.netloc and "vx" not in url.netloc:
+            #msg_to_send += f"[Link {idx}](https://fxtwitter.com{url.path}) "
             msg_to_send += f"https://fxtwitter.com{url.path} "
-        if "pixiv" in url.netloc and "fx" not in url.netloc:
+        if "pixiv" in url.netloc and "fx" not in url.netloc and "vx" not in url.netloc:
+            #msg_to_send += f"[Link {idx}](https://fxpixiv.net{url.path}) "
             msg_to_send += f"https://fxpixiv.net{url.path} "
 
     # If the message had URLs that werent twitter or pixiv, skip the fixing.
     if msg_to_send:
-        msg_to_send = f"He trobat contingut que es veu incorrectament en Discord i l'he corregit!\n{msg_to_send}"
         await msg.respond(msg_to_send, reply=True)
         # The embed in the original message may be delayed. Supress it after the timeout.
         await asyncio.sleep(10)

--- a/src/plugins/fxurl.py
+++ b/src/plugins/fxurl.py
@@ -35,7 +35,7 @@ async def on_message(event: hikari.MessageCreateEvent) -> None:
         if "twitter" in url.netloc and "fx" not in url.netloc and "vx" not in url.netloc:
             #msg_to_send += f"[Link {idx}](https://fxtwitter.com{url.path}) "
             msg_to_send += f"https://fxtwitter.com{url.path} "
-        if "pixiv" in url.netloc and "fx" not in url.netloc and "vx" not in url.netloc:
+        if "pixiv" in url.netloc and "fx" not in url.netloc:
             #msg_to_send += f"[Link {idx}](https://fxpixiv.net{url.path}) "
             msg_to_send += f"https://fxpixiv.net{url.path} "
 

--- a/src/plugins/fxurl.py
+++ b/src/plugins/fxurl.py
@@ -32,11 +32,15 @@ async def on_message(event: hikari.MessageCreateEvent) -> None:
 
     for idx, i in enumerate(urls):
         url = urlparse(i)
-        if "twitter" in url.netloc and "fx" not in url.netloc and "vx" not in url.netloc:
-            #msg_to_send += f"[Link {idx}](https://fxtwitter.com{url.path}) "
+        if (
+            "twitter" in url.netloc
+            and "fx" not in url.netloc
+            and "vx" not in url.netloc
+        ):
+            # msg_to_send += f"[Link {idx}](https://fxtwitter.com{url.path}) "
             msg_to_send += f"https://fxtwitter.com{url.path} "
         if "pixiv" in url.netloc and "fx" not in url.netloc:
-            #msg_to_send += f"[Link {idx}](https://fxpixiv.net{url.path}) "
+            # msg_to_send += f"[Link {idx}](https://fxpixiv.net{url.path}) "
             msg_to_send += f"https://fxpixiv.net{url.path} "
 
     # If the message had URLs that werent twitter or pixiv, skip the fixing.

--- a/src/plugins/word_filter.py
+++ b/src/plugins/word_filter.py
@@ -1,0 +1,51 @@
+import re
+import typing as t
+
+import hikari
+from text_unidecode import unidecode
+
+from src import utils, main
+
+plugin = utils.Plugin("FX URLs")
+
+
+@plugin.listener(hikari.MessageCreateEvent)  # type: ignore
+async def on_message_create(event: hikari.MessageCreateEvent) -> None:
+    msg = event.message
+
+    if not msg.content:
+        return
+
+
+@plugin.listener(hikari.MessageUpdateEvent)  # type: ignore
+async def on_message_edit(event: hikari.MessageUpdateEvent) -> None:
+    msg = event.message
+
+    if not msg.content:
+        return
+
+
+async def normalize_message_content(content: str) -> t.Set[str]:
+    # Normalize all unicode characters (removes accents, characters that look like other characters,
+    # and language characters outside ascii)
+    content = unidecode(content)
+    # Make it all lowercase
+    content = content.lower()
+    # Remove all numbers
+    content = re.sub(r"\d+", "", content)
+    # Remove all punctuation (everything that's not a word)
+    content = re.sub(r"[^\w\s]", "", content)
+    # Remove any character that's not ASCII
+    content = re.sub(r"[^\x00-\x7F]+", "", content)
+    # Remove heading and footing whitespaces
+    content = content.strip()
+    # Split all the words (by newline and whitespaces)
+    words_list = content.split()
+    # Deduplicate the words and make search O(1)
+    words_set = set(words_list)
+
+    return words_set
+
+
+def load(bot: main.CiberBot) -> None:
+    bot.add_plugin(plugin)


### PR DESCRIPTION
introduces a markdown parser so that the bot can understand the message formatting in the same way clients display it, and use it in `fxurl.py`.

consequences:
 - only process links that discord recognizes as such (urls appearing inside code spans or code blocks are no longer detected)
 - only process previewing links (if user disables preview with `<url>`, skip it)
 - skip links inside spoilers

also took the opportunity to restrict the tests we make on the detected links:
 - only consider http links (just in case)
 - hostname must exactly match against a list
 - for twitter, the link must be to a tweet or tweet photo (things like homepage, profiles, intents, etc. are now skipped)

I also added some normalizations for correctness:
 - normalize escapes by unquoting/quoting
 - case insensitive comparison of hostname

**edit:** rebased on top of the `fxurl` branch, which also brings the following changes:
 - remove the explanatory note on fxurl messages
 - WIP word filter